### PR TITLE
Avoid forcing dart

### DIFF
--- a/addon/styles/_mixins.scss
+++ b/addon/styles/_mixins.scss
@@ -1,19 +1,17 @@
-@use "sass:math";
-
 @mixin arrow($position, $width) {
   @if ($position == 'top') {
     transform: rotate(-45deg);
-    bottom: math.div(-$width, 2);
+    bottom: -$width * .5;
   } @else if ($position == 'bottom') {
     transform: rotate(135deg);
-    top: math.div(-$width, 2);
+    top: -$width * .5;
   } @else if ($position == 'left') {
     transform: rotate(225deg);
-    right: math.div(-$width, 2);
+    right: -$width * .5;
     top: 50%;
   } @else if ($position == 'right') {
     transform: rotate(45deg);
-    left: math.div(-$width, 2);
+    left: -$width * .5;
     top: 50%;
   }
 }


### PR DESCRIPTION
Although node-sass is deprecated, it is still quite fast compared to dart. This change makes it so it is not necessary to exclude node-sass, for the same effect.